### PR TITLE
fix cant reversal when create rail

### DIFF
--- a/.patching-mods/main.yaml
+++ b/.patching-mods/main.yaml
@@ -95,6 +95,7 @@ mods:
       - jp.ngt.rtm.rail.TileEntityTurnTableCore
       - jp.ngt.rtm.rail.util.MarkerState
       - jp.ngt.rtm.rail.util.RailMaker
+      - jp.ngt.rtm.rail.util.RailMapBasic
       - jp.ngt.rtm.rail.util.SwitchType
       - jp.ngt.rtm.render.ModelObject
       - jp.ngt.rtm.render.PartsRenderer

--- a/src/main/rtm-patches/jp/ngt/rtm/rail/util/RailMapBasic.java.patch
+++ b/src/main/rtm-patches/jp/ngt/rtm/rail/util/RailMapBasic.java.patch
@@ -1,0 +1,18 @@
+--- a/jp/ngt/rtm/rail/util/RailMapBasic.java
++++ b/jp/ngt/rtm/rail/util/RailMapBasic.java
+@@ -14,10 +14,15 @@
+    protected ILine lineVertical;
+ 
+    public RailMapBasic(RailPosition par1, RailPosition par2) {
+       this.startRP = par1;
+       this.endRP = par2;
++      if (this.startRP.cantEdge * this.startRP.cantCenter < 0) {
++         this.startRP.cantCenter = -this.startRP.cantCenter;
++      } else if (this.startRP.cantEdge * this.startRP.cantCenter == 0 && this.endRP.cantEdge * this.startRP.cantCenter > 0) {
++         this.startRP.cantCenter = -this.startRP.cantCenter;
++      }
+       this.endRP.cantCenter = this.startRP.cantCenter;
+       this.createLine();
+    }
+ 
+    protected void createLine() {


### PR DESCRIPTION
逆カントやカント逆転などと呼ばれている、レール作成時に中央部のカントがGuiの表示と異なり逆転してしまう問題の修正となります。
Port from Kai-Z-JP/KaizPatchX@25e4018f269da5f4eb75e44576191d570e3b24e7